### PR TITLE
logSuccess(msg) perform logging only for non-error computations

### DIFF
--- a/src/main/scala/com/emarsys/logger/LoggerSyntax.scala
+++ b/src/main/scala/com/emarsys/logger/LoggerSyntax.scala
@@ -5,7 +5,6 @@ import cats.{Applicative, MonadError}
 import com.emarsys.logger.internal.{LoggingContextMagnet, VarArgLoggableEncoder}
 import com.emarsys.logger.loggable.{LoggableObject, LoggableValue}
 import cats.syntax.applicativeError._
-import cats.syntax.apply._
 import cats.syntax.flatMap._
 
 import scala.language.implicitConversions
@@ -101,7 +100,7 @@ final class LoggingOps[F[_], A](val fa: F[A]) extends AnyVal {
   def logSuccess(
       msg: String
   )(implicit logging: Logging[F], me: MonadError[F, Throwable], magnet: LoggingContextMagnet[F]): F[A] =
-    fa <* logging.info(msg)
+    fa.flatTap(_ => logging.info(msg))
 
   def logSuccess(
       createMsg: A => String

--- a/src/test/scala/com/emarsys/logger/LoggingSyntaxLogSuccessFailureSpec.scala
+++ b/src/test/scala/com/emarsys/logger/LoggingSyntaxLogSuccessFailureSpec.scala
@@ -1,0 +1,75 @@
+package com.emarsys.logger
+
+import java.util.UUID
+
+import cats.instances.future._
+import ch.qos.logback.classic.Logger
+import com.emarsys.logger.testutil.TestAppender
+import org.scalatest.{Matchers, WordSpec}
+import org.slf4j.LoggerFactory
+import com.emarsys.logger.syntax._
+import scala.concurrent.duration._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, Future}
+
+class LoggingSyntaxLogSuccessFailureSpec extends WordSpec with Matchers {
+  "LoggingSyntax" should {
+    def await[T](f: Future[T]) = Await.ready(f, 1.second)
+
+    "logSuccess for completed future" in new LoggingScope {
+      await {
+        Future[Int](1)
+          .logSuccess("logSuccess")
+          .logFailure("logFailure")
+      }
+      appender.events.length shouldBe 1
+      appender.events.head.getMessage shouldBe "logSuccess"
+    }
+    "logSuccess with value for completed future" in new LoggingScope {
+      await {
+        Future[Int](1)
+          .logSuccess(r => s"logSuccess $r")
+          .logFailure(e => s"logFailure $e")
+      }
+      appender.events.length shouldBe 1
+      appender.events.head.getMessage shouldBe "logSuccess 1"
+    }
+    "logFailure for failed future" in new LoggingScope {
+      await {
+        Future
+          .failed[Int](new RuntimeException("Fail!"))
+          .logSuccess("logSuccess")
+          .logFailure("logFailure")
+      }
+      appender.events.length shouldBe 1
+      appender.events.head.getMessage shouldBe "logFailure"
+    }
+    "logFailure with value for failed future" in new LoggingScope {
+      await {
+        Future
+          .failed[Int](new RuntimeException("Fail!"))
+          .logSuccess(r => s"logSuccess $r")
+          .logFailure(e => s"logFailure $e")
+      }
+      appender.events.length shouldBe 1
+      appender.events.head.getMessage shouldBe "logFailure java.lang.RuntimeException: Fail!"
+    }
+  }
+
+  trait LoggingScope {
+
+    private val loggerName: String              = UUID.randomUUID().toString.take(8)
+    implicit val loggingContext: LoggingContext = LoggingContext(loggerName)
+    private val unsafeLogger                    = Logging.createUnsafeLogger(loggerName)
+    implicit val logger: Logging[Future] =
+      Logging.create[Future]((level, msg, ctx) => Future.successful(unsafeLogger.log(level, msg, ctx)))
+
+    val appender = new TestAppender
+    appender.start()
+
+    private val underlyingLogger = LoggerFactory.getLogger(loggerName).asInstanceOf[Logger]
+    underlyingLogger.detachAndStopAllAppenders()
+    underlyingLogger.addAppender(appender)
+  }
+}


### PR DESCRIPTION
without fix logSuccess method log message for errors,  see spec ("logFailure for failed future")

`
2 was not equal to 1
ScalaTestFailureLocation: com.emarsys.logger.LoggingSyntaxLogSuccessFailureSpec$$anon$3 at (LoggingSyntaxLogSuccessFailureSpec.scala:45)
Expected :1
Actual   :2
`